### PR TITLE
Fix accessible-emoji warnings

### DIFF
--- a/src/Footer.js
+++ b/src/Footer.js
@@ -6,7 +6,7 @@ function Footer(){
         <footer>
             <div className="container">
                 <center>
-                    <p className="p-footer">Made with ❤️ by <a href="https://github.com/surajondev">Suraj Vishwakarma</a></p>
+                    <p className="p-footer">Made with <span role="img" aria-labelledby="love">❤️</span> by <a href="https://github.com/surajondev">Suraj Vishwakarma</a></p>
                     <p className="p-footer">Source <a href="https://openweathermap.org/">OpenWeather</a></p>
                 </center>
             </div>

--- a/src/Header.js
+++ b/src/Header.js
@@ -5,7 +5,7 @@ function Header() {
   return (
     <header>
       <div className="container ui block header">
-        <h1 className="tittle">GET WEATHER 💨</h1>
+        <h1 className="tittle">GET WEATHER <span role="img" aria-labelledby="weather">💨</span></h1>
       </div>
     </header>
   );


### PR DESCRIPTION
Fix accessible-emoji warnings

```
./src/Header.js
  Line 8:9:  Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji

./src/Footer.js
  Line 9:21:  Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
```