### PR TITLE
Move heading left

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -1,14 +1,17 @@
 import React from "react";
 import "./index.css";
-import {TiWeatherSunny} from 'react-icons/ti'
+import { TiWeatherSunny } from "react-icons/ti";
 
 function Header() {
   return (
     <header>
-      <div className="container ui block header">
-      <h1 className="title">
-    GET WEATHER <span className="logo"><TiWeatherSunny/></span>
-  </h1>
+      <div className='container ui block header'>
+        <h1 className='title'>
+          GET WEATHER{" "}
+          <span className='logo'>
+            <TiWeatherSunny />
+          </span>
+        </h1>
       </div>
     </header>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,7 @@ a:hover {
 
 /* TYPOGRAPHY */
 .title {
+  text-align: left;
   font-size: 4rem;
   font-weight: 50px;
   padding-left: 0.6rem;


### PR DESCRIPTION
This PR fixes: https://github.com/surajondev/get-weather/issues/51

I've added a text-align: left rule to .title that  does exactly that.

Here is a screenshot of how it looks now when the toast message appears:

![image](https://github.com/surajondev/get-weather/assets/4129325/c28c7810-858c-4da2-ab69-b727d91b9edf)

Please tell me if this is ok. If not I can make an update :)